### PR TITLE
Update ParalysisAttack jewel size to 2 from 1

### DIFF
--- a/src/armor_and_skills.rs
+++ b/src/armor_and_skills.rs
@@ -506,7 +506,7 @@ impl Skill {
 
             ParalysisAttack => SkillDesc {
                 limit: 3,
-                jewel_size: Some(1),
+                jewel_size: Some(2),
             },
 
             PierceUp => SkillDesc {


### PR DESCRIPTION
I noticed while optimizing a Paralyze build that the Paralyze Jewel was being treated as a level 1 jewel when it's actually level 2.

Great work on the project as a whole by the way!